### PR TITLE
ci: [ATL-1640] add swiftlint

### DIFF
--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -22,6 +22,14 @@ jobs:
           VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           DISABLE: COPYPASTE,SPELL
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISABLE_LINTERS: SWIFT_SWIFTLINT
+
+      - name: SwiftLint
+        uses: norio-nomura/action-swiftlint@3.2.1
+        with:
+          args: --strict
+        env:
+          DIFF_BASE: ${{ github.base_ref }}
 
       - name: Archive production artifacts
         if: success() || failure()

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,105 +1,105 @@
 disabled_rules:
-- todo
-- colon
-- opening_brace
-- reduce_into
-- vertical_parameter_alignment_on_call
-- array_init
+  - todo
+  - colon
+  - opening_brace
+  - reduce_into
+  - vertical_parameter_alignment_on_call
+  - array_init
 opt_in_rules:
-- force_unwrapping
-- force_cast
-- anyobject_protocol
-- array_init
-- closure_spacing
-- collection_alignment
-- contains_over_filter_count
-- contains_over_filter_is_empty
-- contains_over_first_not_nil
-- contains_over_range_nil_comparison
-- empty_collection_literal
-- empty_count
-- empty_string
-- empty_xctest_method
-- enum_case_associated_values_count
-- explicit_init
-- extension_access_modifier
-- fallthrough
-- fatal_error_message
-- file_header
-- flatmap_over_map_reduce
-- identical_operands
-- joined_default_parameter
-- last_where
-- legacy_multiple
-- legacy_random
-- literal_expression_end_indentation
-- lower_acl_than_parent
-- modifier_order
-- nimble_operator
-- nslocalizedstring_key
-- number_separator
-- operator_usage_whitespace
-- overridden_super_call
-- override_in_extension
-- pattern_matching_keywords
-- prefer_self_type_over_type_of_self
-- private_action
-- private_outlet
-- prohibited_interface_builder
-- prohibited_super_call
-- quick_discouraged_call
-- quick_discouraged_focused_test
-- quick_discouraged_pending_test
-- reduce_into
-- redundant_nil_coalescing
-- redundant_type_annotation
-- single_test_class
-- sorted_first_last
-- sorted_imports
-- static_operator
-- strong_iboutlet
-- test_case_accessibility
-- toggle_bool
-- unavailable_function
-- unneeded_parentheses_in_closure_argument
-- unowned_variable_capture
-- untyped_error_in_catch
-- vertical_parameter_alignment_on_call
-- vertical_whitespace_closing_braces
-- vertical_whitespace_opening_braces
-- xct_specific_matcher
-- yoda_condition
+  - force_unwrapping
+  - force_cast
+  - anyobject_protocol
+  - array_init
+  - closure_spacing
+  - collection_alignment
+  - contains_over_filter_count
+  - contains_over_filter_is_empty
+  - contains_over_first_not_nil
+  - contains_over_range_nil_comparison
+  - empty_collection_literal
+  - empty_count
+  - empty_string
+  - empty_xctest_method
+  - enum_case_associated_values_count
+  - explicit_init
+  - extension_access_modifier
+  - fallthrough
+  - fatal_error_message
+  - file_header
+  - flatmap_over_map_reduce
+  - identical_operands
+  - joined_default_parameter
+  - last_where
+  - legacy_multiple
+  - legacy_random
+  - literal_expression_end_indentation
+  - lower_acl_than_parent
+  - modifier_order
+  - nimble_operator
+  - nslocalizedstring_key
+  - number_separator
+  - operator_usage_whitespace
+  - overridden_super_call
+  - override_in_extension
+  - pattern_matching_keywords
+  - prefer_self_type_over_type_of_self
+  - private_action
+  - private_outlet
+  - prohibited_interface_builder
+  - prohibited_super_call
+  - quick_discouraged_call
+  - quick_discouraged_focused_test
+  - quick_discouraged_pending_test
+  - reduce_into
+  - redundant_nil_coalescing
+  - redundant_type_annotation
+  - single_test_class
+  - sorted_first_last
+  - sorted_imports
+  - static_operator
+  - strong_iboutlet
+  - test_case_accessibility
+  - toggle_bool
+  - unavailable_function
+  - unneeded_parentheses_in_closure_argument
+  - unowned_variable_capture
+  - untyped_error_in_catch
+  - vertical_parameter_alignment_on_call
+  - vertical_whitespace_closing_braces
+  - vertical_whitespace_opening_braces
+  - xct_specific_matcher
+  - yoda_condition
 excluded:
-- build
-- Pods
-- protobuf
-- PrismAPISDK
-- Sources/PrismSwiftSDK/protobuf
-- Tests/PrismSwiftSDKTests
+  - build
+  - Pods
+  - protobuf
+  - PrismAPISDK
+  - Sources/PrismSwiftSDK/protobuf
+  - Tests/PrismSwiftSDKTests
 line_length:
-    ignores_comments: true
-    ignores_urls: true
+  ignores_comments: true
+  ignores_urls: true
 function_body_length:
-    warning: 100
-    error: 200
+  warning: 100
+  error: 200
 type_body_length:
-    warning: 350
-    error: 700
+  warning: 350
+  error: 700
 file_length:
-    ignore_comment_only_lines: true
+  ignore_comment_only_lines: true
 cyclomatic_complexity:
-    warning: 25
-    error: 50
+  warning: 25
+  error: 50
 function_parameter_count:
-    warning: 12
-    error: 20
+  warning: 12
+  error: 20
 large_tuple:
   warning: 4
   error: 5
 nesting:
   type_level: 3
 identifier_name:
-  max_length: 
+  max_length:
     warning: 40
     error: 100
   allowed_symbols: ["_"] # these are allowed in constants names


### PR DESCRIPTION
Megalinter doesnt work well with swiftlint. This issue has been reported in the ticket below.
While a solution is not provided we will go forward with having this swiftlint action and disable the
megalinter swiftlint process.
https://github.com/oxsecurity/megalinter/issues/440