### PR TITLE
feat(pollux): add anoncreds predicate on requests

### DIFF
--- a/EdgeAgentSDK/EdgeAgent/Sources/EdgeAgent+Credentials.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/EdgeAgent+Credentials.swift
@@ -48,7 +48,7 @@ public extension EdgeAgent {
         )
 
         let rqstStr = try request.tryToString()
-        Logger(label: "").log(level: .info, "Request: \(rqstStr)")
+        logger.debug(message: "Request: \(rqstStr)")
         let attachment: AttachmentDescriptor
         switch type {
         case .jwt:

--- a/EdgeAgentSDK/EdgeAgent/Tests/AnoncredsPresentationFlowTest.swift
+++ b/EdgeAgentSDK/EdgeAgent/Tests/AnoncredsPresentationFlowTest.swift
@@ -40,7 +40,8 @@ final class AnoncredsPresentationFlowTest: XCTestCase {
             fromDID: DID(method: "test", methodId: "alice"),
             toDID: DID(method: "test", methodId: "bob"),
             claimFilters: [
-                .init(paths: [], type: "sex")
+                .init(paths: [], type: "sex"),
+                .init(paths: [], type: "age", const: "20", pattern: ">=")
             ]
         )
 

--- a/EdgeAgentSDK/Pollux/Sources/PolluxImpl+Presentation.swift
+++ b/EdgeAgentSDK/Pollux/Sources/PolluxImpl+Presentation.swift
@@ -54,15 +54,34 @@ extension PolluxImpl {
                 .reduce([String: AnoncredsPresentationRequest.RequestedAttribute](), { partialResult, filter in
                     var dic = partialResult
                     let key = filter.name ?? filter.type
+                    guard filter.pattern == nil else {
+                        return dic
+                    }
                     dic[key] = AnoncredsPresentationRequest.RequestedAttribute(name: key, restrictions: [])
                     return dic
                 })
+
+            let requestedPredicates = claimFilters
+                .reduce([String: AnoncredsPresentationRequest.RequestedPredicate](), { partialResult, filter in
+                    var dic = partialResult
+                    guard
+                        let pType = filter.pattern,
+                        let pValueStr = filter.const,
+                        let pValue = Int(pValueStr)
+                    else {
+                        return dic
+                    }
+                    let key = filter.name ?? filter.type
+                    dic[key] = AnoncredsPresentationRequest.RequestedPredicate(name: key, pType: pType, pValue: pValue)
+                    return dic
+                })
+            
             let anoncredsPresentation = AnoncredsPresentationRequest(
                 nonce: try Nonce().getValue(),
                 name: name,
                 version: version,
                 requestedAttributes: requestedFields,
-                requestedPredicates: [:]
+                requestedPredicates: requestedPredicates
             )
 
             return try JSONEncoder.didComm().encode(anoncredsPresentation)


### PR DESCRIPTION
### Description:
Add ability to add predicates on anoncreds presentation requests.
 
 Fixes ATL-6848 ATL-6517

### Checklist: 
- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-swift/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
