### PR TITLE
fix: Update Package.swift to use HTTPS for swift-protobuf dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
             url: "https://github.com/apple/swift-log.git",
             from: "1.4.4"
         ),
-        .package(url: "git@github.com:apple/swift-protobuf.git", from: "1.7.0"),
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.7.0"),
         .package(url: "https://github.com/beatt83/didcomm-swift.git", from: "0.1.8"),
         .package(url: "https://github.com/beatt83/jose-swift.git", from: "3.1.0"),
         .package(url: "https://github.com/beatt83/peerdid-swift.git", from: "3.0.1"),


### PR DESCRIPTION
### Description: 
Hey there, this is just a simple change that I made to help fix the setup on my mac for cloning the sample project. Both my friend (@Jack-Severson) and I were having issues with building the demo wallet app in Xcode 15.4 or adding the package to a new project due to an issue with fetching `swift-protobuf`.

I ultimately narrowed the issue down to the Package.swift file using the SSH format for cloning the `swift-protobuf` package and timing out on our machines. I changes the the format to HTTPS and was then able to successfully resolve dependencies and build the app. 

### Checklist: 
- [X] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-swift/blob/main/CONTRIBUTING.md) of this project
- [X] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
