### PR TITLE
feat(agent): init now receives a seed callback

### DIFF
--- a/EdgeAgentSDK/EdgeAgent/Sources/DIDCommAgent/DIDCommAgent.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/DIDCommAgent/DIDCommAgent.swift
@@ -73,7 +73,7 @@ public class DIDCommAgent {
         - mediatorServiceEnpoint: Optional DID representing the service endpoint of the mediator. If not provided, the default Prism mediator endpoint will be used.
     */
     public convenience init(
-        seedData: Data? = nil,
+        seedData: (() async throws -> Data)? = nil,
         mediatorDID: DID
     ) {
         let edgeAgent = EdgeAgent(seedData: seedData)

--- a/EdgeAgentSDK/EdgeAgent/Sources/EdgeAgent+Backup.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/EdgeAgent+Backup.swift
@@ -56,6 +56,7 @@ extension EdgeAgent {
      - Note: The backup's security is heavily dependent on the secrecy and strength of the seed used to initialize the wallet. Users must ensure that their seed is kept in a secure location and never shared.
      */
     public func backupWallet() async throws -> String {
+        let seed = try await self.seed()
         let backup = Backup(
             keys: try await backupKeys(),
             linkSecret: try await backupLinkSecret(),
@@ -105,6 +106,7 @@ extension EdgeAgent {
      - Note: The accuracy of the wallet recovery is entirely reliant on the backup being created and encrypted correctly, as well as the wallet being initialized with the same seed used during backup. Users must ensure that the seed and encrypted backup are securely stored and handled.
      */
     public func recoverWallet(encrypted: String) async throws {
+        let seed = try await seed()
         let masterKey = try self.apollo.createPrivateKey(parameters: [
             KeyProperties.type.rawValue: "EC",
             KeyProperties.curve.rawValue: KnownKeyCurves.x25519.rawValue,

--- a/EdgeAgentSDK/EdgeAgent/Sources/EdgeAgent+DIDHigherFucntions.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/EdgeAgent+DIDHigherFucntions.swift
@@ -85,7 +85,7 @@ Could not find key in storage please use Castor instead and provide the private 
         alias: String? = nil,
         services: [DIDDocument.Service] = []
     ) async throws -> DID {
-        let seed = self.seed
+        let seed = try await self.seed()
         let apollo = self.apollo
         let castor = self.castor
         var usingKeys = keys

--- a/EdgeAgentSDK/EdgeAgent/Sources/EdgeAgent.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/EdgeAgent.swift
@@ -8,7 +8,7 @@ import Foundation
 /// a provided Mediator Service Endpoint and seed data.
 public class EdgeAgent {
     /// Represents the seed data used to create a unique DID.
-    public let seed: Seed
+    public let seed: () async throws -> Seed
 
     let logger = SDKLogger(category: LogComponent.edgeAgent)
     public let apollo: Apollo & KeyRestoration
@@ -29,36 +29,46 @@ public class EdgeAgent {
     ///   - pluto: An instance of Pluto.
     ///   - pollux: An instance of Pollux.
     ///   - mercury: An instance of Mercury.
-    ///   - seed: A unique seed used to generate the unique DID.
-    ///   - mediatorServiceEnpoint: The endpoint of the Mediator service to use.
+    ///   - seed: A seed builder that will be called when the SDK requires to use the seed. If nil the SDK will create a random seed and use that.
     public init(
         apollo: Apollo & KeyRestoration,
         castor: Castor,
         pluto: Pluto,
         pollux: Pollux & CredentialImporter,
-        seed: Seed? = nil
+        seed: (() async throws -> Seed)? = nil
     ) {
         self.apollo = apollo
         self.castor = castor
         self.pluto = pluto
         self.pollux = pollux
-        self.seed = seed ?? apollo.createRandomSeed().seed
+        if let seed {
+            self.seed = seed
+        } else {
+            let usingSeed = apollo.createRandomSeed().seed
+            self.seed = { usingSeed }
+        }
     }
 
     /**
       Convenience initializer for `EdgeAgent` that allows for optional initialization of seed data and mediator service endpoint.
 
       - Parameters:
-        - seedData: Optional seed data for creating a new seed. If not provided, a random seed will be generated.
-        - mediatorServiceEnpoint: Optional DID representing the service endpoint of the mediator. If not provided, the default Prism mediator endpoint will be used.
+        - seedDataBuilder: Optional seed builder that will be called when the SDK requires to use the seed. If nil the SDK will create a random seed and use that.
     */
-    public convenience init(seedData: Data? = nil) {
+    public convenience init(seedData: (() async throws -> Data)? = nil) {
         let apollo = ApolloBuilder().build()
         let castor = CastorBuilder(apollo: apollo).build()
         let pluto = PlutoBuilder().build()
         let pollux = PolluxBuilder(pluto: pluto, castor: castor).build()
 
-        let seed = seedData.map { Seed(value: $0) } ?? apollo.createRandomSeed().seed
+        let seed: () async throws -> Seed
+        if let seedData {
+            seed = { try await Seed(value: seedData()) }
+        } else {
+            let seedData = apollo.createRandomSeed().seed
+            seed = { seedData }
+        }
+
         self.init(
             apollo: apollo,
             castor: castor,

--- a/EdgeAgentSDK/EdgeAgent/Sources/OIDCAgent/OIDCAgent.swift
+++ b/EdgeAgentSDK/EdgeAgent/Sources/OIDCAgent/OIDCAgent.swift
@@ -36,7 +36,7 @@ public class OIDCAgent {
         - mediatorServiceEnpoint: Optional DID representing the service endpoint of the mediator. If not provided, the default Prism mediator endpoint will be used.
     */
     public convenience init(
-        seedData: Data? = nil
+        seedData: (() async throws -> Data)? = nil
     ) {
         let edgeAgent = EdgeAgent(seedData: seedData)
 

--- a/EdgeAgentSDK/EdgeAgent/Tests/BackupWalletTests.swift
+++ b/EdgeAgentSDK/EdgeAgent/Tests/BackupWalletTests.swift
@@ -24,12 +24,13 @@ final class BackupWalletTests: XCTestCase {
         let castor = CastorImpl(apollo: apollo)
         let pluto = MockPluto()
         let pollux = MockPollux()
+        let seed = seed
         let agent = EdgeAgent(
             apollo: apollo,
             castor: castor,
             pluto: pluto,
             pollux: pollux,
-            seed: seed
+            seed: { seed }
         )
         return (agent, pluto)
     }
@@ -39,12 +40,13 @@ final class BackupWalletTests: XCTestCase {
         let castor = CastorImpl(apollo: apollo)
         let pluto = PlutoImpl(setup: .init(coreDataSetup: .init(modelPath: .storeName("PrismPluto"), storeType: .memory), keychain: KeychainMock()))
         let pollux = PolluxImpl(castor: castor, pluto: pluto)
+        let seed = seed
         let agent = EdgeAgent(
             apollo: apollo,
             castor: castor,
             pluto: pluto,
             pollux: pollux,
-            seed: seed
+            seed: { seed }
         )
         return (agent, pluto)
     }

--- a/EdgeAgentSDK/EdgeAgent/Tests/PrismOnboardingInvitationTests.swift
+++ b/EdgeAgentSDK/EdgeAgent/Tests/PrismOnboardingInvitationTests.swift
@@ -39,7 +39,8 @@ final class PrismOnboardingInvitationTests: XCTestCase {
             apollo: apollo,
             castor: CastorBuilder(apollo: apollo).build(),
             pluto: MockPluto(),
-            pollux: MockPollux()
+            pollux: MockPollux(),
+            seed: nil
         )
         let didcommAgent = DIDCommAgent(
             edgeAgent: edgeAgent,
@@ -62,7 +63,8 @@ final class PrismOnboardingInvitationTests: XCTestCase {
             apollo: apollo,
             castor: CastorBuilder(apollo: apollo).build(),
             pluto: MockPluto(),
-            pollux: MockPollux()
+            pollux: MockPollux(),
+            seed: nil
         )
         let didcommAgent = DIDCommAgent(
             edgeAgent: edgeAgent,


### PR DESCRIPTION
### Description

This enables that the seed is not kept saved in memory in the edge agent, but can be requested when needed

### Checklist

- [x] My PR follows the [contribution guidelines](https://github.com/input-output-hk/atala-prism-wallet-sdk-swift/blob/main/CONTRIBUTING.md) of this project
- [x] My PR is free of third-party dependencies that don't comply with the [Allowlist](https://toc.hyperledger.org/governing-documents/allowed-third-party-license-policy.html#approved-licenses-for-allowlist)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked the PR title to follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/)
